### PR TITLE
Remove branded references

### DIFF
--- a/docs/3_completed/phase-1-project-tooling-setup-idea/phase-1-project-tooling-setup-idea.md
+++ b/docs/3_completed/phase-1-project-tooling-setup-idea/phase-1-project-tooling-setup-idea.md
@@ -2,7 +2,7 @@
 
 1. **Bootstrap Next.js project**
 
-   - `pnpm dlx create-next-app@latest lh3-web --ts`
+   - `pnpm dlx create-next-app@latest web-app --ts`
    - Pin Next.js to v15.3.2: `pnpm add next@15.3.2 react react-dom`
 
 2. **Install & configure Tailwind v4**

--- a/docs/3_completed/phase-1-project-tooling-setup-idea/summary.md
+++ b/docs/3_completed/phase-1-project-tooling-setup-idea/summary.md
@@ -1,4 +1,4 @@
-This completed phase focused on the foundational tooling and project setup for a new web application, "lh3-web". The core deliverables included bootstrapping a Next.js project, specifically pinning it to version 15.3.2, and integrating key frontend and backend technologies.
+This completed phase focused on the foundational tooling and project setup for a new web application, "web-app". The core deliverables included bootstrapping a Next.js project, specifically pinning it to version 15.3.2, and integrating key frontend and backend technologies.
 
 On the frontend side, the setup involved installing and configuring Tailwind CSS version 4 for styling, including the creation of a config file and updating content paths. Additionally, shadcn/ui was added and initialized, with a note to select common components like Buttons, Forms, and Cards, and to audit/tweak the theme tokens.
 

--- a/docs/3_completed/phase-2-ux-ui-scaffold/design.md
+++ b/docs/3_completed/phase-2-ux-ui-scaffold/design.md
@@ -18,11 +18,11 @@ _(These are textual descriptions. Actual wireframes/mockups would be created in 
 
 - **Main Layout (Option 2 - Modern Collapsible Overlay Sidebar):**
   - **Desktop:**
-    - Header: Full-width, fixed at the top. "LH3 (Larryville Hash House Harriers)" Logo left, navigation links ("Feed", "Events", "Members") center/right. "Admin Mode" toggle and user profile icon on the far right. A toggle icon (e.g., hamburger or a specific sidebar icon) to open the sidebar.
+    - Header: Full-width, fixed at the top. Application logo left, navigation links ("Feed", "Events", "Members") center/right. "Admin Mode" toggle and user profile icon on the far right. A toggle icon (e.g., hamburger or a specific sidebar icon) to open the sidebar.
     - Main Content: Occupies full viewport width below the header. Example content: a scrollable feed of user posts, event cards.
     - Sidebar: Slides in as an overlay from the left or right when toggled. Width ~280-320px. Contains sections like "Upcoming Events" (list of events), "Quick Stats" (e.g., Active Members, Hash Cash Pool), and "Admin Tools" (e.g., Attendance Tracking, Hash Cash Management).
   - **Mobile/Tablet:**
-    - Header: Similar to desktop, primary navigation links ("Feed", "Events", "Members") might collapse into a menu triggered by an icon, or be part of the main sidebar. "LH3" Logo, Admin toggle, Profile icon, and Sidebar toggle visible.
+    - Header: Similar to desktop, primary navigation links ("Feed", "Events", "Members") might collapse into a menu triggered by an icon, or be part of the main sidebar. Application logo, Admin toggle, Profile icon, and Sidebar toggle visible.
     - Sidebar: Always an overlay, toggled by its icon. Contains same sections as desktop.
     - Main Content: Full width.
 - **Card Component:**

--- a/docs/3_completed/phase-2-ux-ui-scaffold/uxpilot_prompts.md
+++ b/docs/3_completed/phase-2-ux-ui-scaffold/uxpilot_prompts.md
@@ -2,50 +2,50 @@
 
 ## Global Layout (Option 2: Modern - Collapsible Overlay Sidebar)
 
-**Prompt 1: Main Application Shell - LH3 Desktop View**
-"Design a clean and modern application shell for a community platform called 'LH3'.
+**Prompt 1: Main Application Shell - the application Desktop View**
+"Design a clean and modern application shell for a community platform called 'the application'.
 
-- Header: Fixed at the top, 60px height. Include the 'LH3' logo on the left. Centered or right-aligned, include primary navigation links: 'Feed', 'Events', 'Members'. On the far right, include an 'Admin Mode' toggle switch and a user profile icon/button. Add a distinct icon (e.g., a three-line sidebar icon or a specific 'tools' icon) on the far left to toggle a sidebar.
+- Header: Fixed at the top, 60px height. Include the 'the application' logo on the left. Centered or right-aligned, include primary navigation links: 'Feed', 'Events', 'Members'. On the far right, include an 'Admin Mode' toggle switch and a user profile icon/button. Add a distinct icon (e.g., a three-line sidebar icon or a specific 'tools' icon) on the far left to toggle a sidebar.
 - Sidebar: Initially hidden. When toggled, it should slide in from the right as an overlay, with a width of approx 300px. The sidebar should have a slightly different background color (e.g. light gray if main is white). Include sections with appropriate icons:
-  - 'Upcoming Events': Show 2-3 placeholder event summaries (e.g., 'LH3 #689 - Weekend Trail Run - Sat, Mar 15').
+  - 'Upcoming Events': Show 2-3 placeholder event summaries (e.g., 'the application #689 - Weekend Trail Run - Sat, Mar 15').
   - 'Quick Stats': Show placeholder stats like 'Active Members: 247', 'New Members: 12', 'Hash Cash Pool: 12,450'.
   - 'Admin Tools': List items like 'Attendance Tracking', 'Hash Cash Management', 'Manage Achievements'.
 - Main Content Area: Occupy the remaining space below the header. Display a placeholder for a social feed post, e.g., a card with user avatar, name, timestamp, text content, and an image placeholder.
 - Style: Use a light theme, professional yet engaging for a community. Primary accent color: a vibrant but not overpowering blue (refer to mockup). Font: Clear Sans-serif."
 
-**Prompt 2: Main Application Shell - LH3 Mobile View with Sidebar Open**
-"Design the mobile view of the 'LH3' application shell, specifically showing the sidebar open.
+**Prompt 2: Main Application Shell - the application Mobile View with Sidebar Open**
+"Design the mobile view of the 'the application' application shell, specifically showing the sidebar open.
 
-- Header: Fixed at the top, 50px height. Display the 'LH3' logo (can be smaller) on the left. On the right, include an 'Admin Mode' toggle (if space allows, or it moves to sidebar), a user profile icon, and the sidebar toggle icon.
+- Header: Fixed at the top, 50px height. Display the 'the application' logo (can be smaller) on the left. On the right, include an 'Admin Mode' toggle (if space allows, or it moves to sidebar), a user profile icon, and the sidebar toggle icon.
 - Sidebar: Visible as an overlay, sliding from the right, taking up about 85% of the screen width. It contains the same sections as desktop ('Upcoming Events', 'Quick Stats', 'Admin Tools') stacked vertically. Ensure list items are easily tappable. Add a 'Close' (X) icon at the top left or right of the sidebar.
 - Main Content Area: Partially visible behind the sidebar overlay, possibly dimmed.
 - Style: Clean, touch-friendly, light theme. Consistent with the desktop's vibrant blue accent."
 
-## Common Reusable Components (from spec.md, contextualized for LH3)
+## Common Reusable Components (from spec.md, contextualized for the application)
 
 **Prompt 1: Event Card Component - For 'Upcoming Events' List**
-"Generate a React component for an Event Card, suitable for listing in the 'Upcoming Events' sidebar of LH3.
+"Generate a React component for an Event Card, suitable for listing in the 'Upcoming Events' sidebar of the application.
 
-- Appearance: Compact rectangular card, rounded corners, subtle shadow. Show event title (e.g., 'LH3 #690'), date/time (e.g., 'Mar 22 - 9:00 AM'), and a small icon indicating it's an event (e.g., calendar icon). Add a right-arrow icon or similar to suggest clickability for more details.
-- Content: Props for `eventName`, `eventDate`, `eventTime`, `eventIdentifier` (e.g. 'LH3 #690').
+- Appearance: Compact rectangular card, rounded corners, subtle shadow. Show event title (e.g., 'the application #690'), date/time (e.g., 'Mar 22 - 9:00 AM'), and a small icon indicating it's an event (e.g., calendar icon). Add a right-arrow icon or similar to suggest clickability for more details.
+- Content: Props for `eventName`, `eventDate`, `eventTime`, `eventIdentifier` (e.g. 'the application #690').
 - Style: Clean, information-dense but not cluttered. Use Tailwind CSS. Primary color for accents/icons."
 
 **Prompt 2: Button Component - 'Quick RSVP' Action**
-"Generate a React Button component for a 'Quick RSVP' action on an event card in LH3.
+"Generate a React Button component for a 'Quick RSVP' action on an event card in the application.
 
 - Props: `variant='primary'`, `size='sm'` (or `md` if more prominent), `children` (text label: 'Quick RSVP'), `onClick` handler, optional `icon` (e.g., a checkmark or calendar icon).
-- Appearance (`primary`): Solid background using LH3's primary blue, white text, rounded corners (e.g., 6px), appropriate padding for its size. Hover/active states.
+- Appearance (`primary`): Solid background using the application's primary blue, white text, rounded corners (e.g., 6px), appropriate padding for its size. Hover/active states.
 - Style: Clear call-to-action, noticeable but not oversized for its context. Use Tailwind CSS."
 
 **Prompt 3: Post Input Component - 'Share something with the community...'**
-"Generate a React Input component for creating a new post in the LH3 feed.
+"Generate a React Input component for creating a new post in the the application feed.
 
 - Appearance: A rounded rectangle, wider than a standard input. Inside, on the left, show the current user's avatar (placeholder). To the right of the avatar, display placeholder text like 'Share something with the community...'. Below this main input area, include smaller buttons/icons for 'Photo', 'Discussion', 'Event'.
 - Props: `currentUserAvatarUrl`, `placeholderText`, `onPhotoClick`, `onDiscussionClick`, `onEventClick`.
 - Style: Friendly and inviting. Use Tailwind CSS. Light background, subtle border."
 
 **Prompt 4: Stats Item Component - For 'Quick Stats' Section**
-"Generate a React component to display a single statistic in the 'Quick Stats' section of LH3's sidebar.
+"Generate a React component to display a single statistic in the 'Quick Stats' section of the application's sidebar.
 
 - Appearance: Display a label (e.g., 'Active Members') and its value (e.g., '247') on a single line, or label above value if space is tight. Value should be more prominent (larger font or bolder).
 - Props: `label` (string), `value` (string or number).

--- a/docs/3_completed/phase-5-geocoding-maps/summary.md
+++ b/docs/3_completed/phase-5-geocoding-maps/summary.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Geocoding & Maps feature has been successfully implemented, providing robust location-based functionality for the LH3 application. This feature enhances the user experience when entering and visualizing location data for runs through address autocomplete, interactive map selection, and server-side geocoding capabilities.
+The Geocoding & Maps feature has been successfully implemented, providing robust location-based functionality for the application. This feature enhances the user experience when entering and visualizing location data for runs through address autocomplete, interactive map selection, and server-side geocoding capabilities.
 
 ## Completed Components
 
@@ -138,4 +138,4 @@ The Geocoding & Maps feature has been successfully implemented, providing robust
 - Environment setup instructions in `.env.local.example`
 - Technical decisions documented in `implementation_notes.md`
 
-This feature successfully enhances the LH3 application with modern, user-friendly location selection capabilities while maintaining the existing architecture and design patterns.
+This feature successfully enhances the application with modern, user-friendly location selection capabilities while maintaining the existing architecture and design patterns.

--- a/docs/_reference/completed_features_log.md
+++ b/docs/_reference/completed_features_log.md
@@ -3,6 +3,6 @@
 - **Phase 3 - Authentication:** Completed 2025-05-10. Implemented user authentication using NextAuth.js with Google OAuth and secured API routes.
 - **Phase 2.5 - Data Modeling & Schema:** Completed 2025-05-10. Defined the core data models (User, Run, RSVP, Photo) and relationships using Prisma, enabling database schema migration and client generation.
 - **Phase 2 – UX/UI Scaffold:** Completed 2024-06-10. Established a global layout, reusable design system, and core UI components with a modern, accessible, and extensible foundation for future development.
-- **Phase 1 – Project & Tooling Setup:** Completed 2025-05-10. Established the essential technical stack and initial project structure for lh3-web.
+- **Phase 1 – Project & Tooling Setup:** Completed 2025-05-10. Established the essential technical stack and initial project structure for web-app.
 - **Design System:** Completed 2025-05-09. Integrated shadcn/ui as the foundational design system for the application to provide a consistent and modern look and feel.
 - **Next.js Application Bootstrap:** Completed 2025-05-09. Initialized a new Next.js application with TypeScript, ESLint, and Tailwind CSS, establishing the foundational project structure.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lh3-web",
+  "name": "web-app",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,8 +7,8 @@ import AuthProvider from '@/components/layout/AuthProvider';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
-  title: 'LH3 Application',
-  description: 'Larryville Hash House Harriers',
+  title: 'Application',
+  description: 'A community platform',
 };
 
 export default function RootLayout({

--- a/src/components/layout/header.test.tsx
+++ b/src/components/layout/header.test.tsx
@@ -49,7 +49,7 @@ describe('Header Component', () => {
     renderWithProviders(<Header onToggleSidebar={jest.fn()} />);
 
     expect(screen.getByRole('banner')).toBeInTheDocument();
-    expect(screen.getByText('LH3')).toBeInTheDocument();
+    expect(screen.getByText('App')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /toggle menu/i })).toBeInTheDocument();
   });
 
@@ -203,7 +203,7 @@ describe('Header Component', () => {
 
     // Should still render the basic header structure
     expect(screen.getByRole('banner')).toBeInTheDocument();
-    expect(screen.getByText('LH3')).toBeInTheDocument();
+    expect(screen.getByText('App')).toBeInTheDocument();
   });
 
   it('should maintain header positioning', () => {

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -27,7 +27,7 @@ export default function Header({ onToggleSidebar }: HeaderProps) {
           <Menu className="h-6 w-6" />
         </Button>
         <Link href="/" className="text-xl font-bold">
-          LH3
+          App
         </Link>
       </div>
       <nav className="hidden md:flex space-x-4">


### PR DESCRIPTION
## Summary
- rename package to `web-app`
- change metadata title and header text
- update tests for new header label
- scrub docs and configs of old brand mentions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bff376308321b24fac8fe2c89abb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated all references of the application name from "LH3" or "LH3 Application" to more generic terms such as "App", "Application", or "web-app" across documentation, metadata, and user interface elements.
- **Documentation**
  - Generalized example commands, descriptions, and prompts in documentation to use generic application names instead of specific ones.
- **Tests**
  - Adjusted test assertions to reflect the updated application name in header components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->